### PR TITLE
Added required response to webhook ping check

### DIFF
--- a/index.py
+++ b/index.py
@@ -29,6 +29,8 @@ def index():
         if not is_github:
             abort(403)
 
+        if request.headers.get('X-GitHub-Event') == "ping":
+            return json.dumps({'msg': 'Hi!'})
         repo_name = json.loads(request.data)['repository']['name']
         repo_owner = json.loads(request.data)['repository']['owner']['name']
         repos = json.loads(io.open('repos.json', 'r').read())


### PR DESCRIPTION
Github's new webhook interface sends a ping request to check if the server is up. I added support for that so an error doesn't occur.
