### PR TITLE
Fix signature verification

### DIFF
--- a/index.py
+++ b/index.py
@@ -62,7 +62,7 @@ def index():
 
         if repo and repo.get('path', None):
             # Check if POST request signature is valid
-            key = repos.get('key', None)
+            key = repo.get('key', None)
             if key:
                 signature = request.headers.get('X-Hub-Signature').split('=')[1]
                 mac = hmac(key, msg=request.data, digestmod=sha1)


### PR DESCRIPTION
Signature verification was broken because `repos` refers to the root element of the JSON, where no `key` element is defined, but `repo` refers to a repo, where the `key` element is defined.
Edit: This pull request still needs more work, I'll update it in the next few days
