### PR TITLE
Fix ProxyFix Imported Twice

### DIFF
--- a/index.py
+++ b/index.py
@@ -10,7 +10,21 @@ import ipaddress
 import hmac
 from hashlib import sha1
 from flask import Flask, request, abort
-from werkzeug.contrib.fixers import ProxyFix
+
+"""
+Conditionally import ProxyFix from werkzeug if the USE_PROXYFIX environment
+variable is set to true.  If you intend to import this as a module in your own
+code, use os.environ to set the environment variable before importing this as a
+module.
+
+.. code:: python
+
+    os.environ['USE_PROXYFIX'] = 'true'
+    import flask-github-webhook-handler.index as handler
+
+"""
+if os.environ.get('USE_PROXYFIX', None) == 'true':
+    from werkzeug.contrib.fixers import ProxyFix
 
 app = Flask(__name__)
 app.debug = os.environ.get('DEBUG') == 'true'
@@ -109,7 +123,5 @@ if __name__ == "__main__":
         port_number = int(sys.argv[1])
     except:
         port_number = 80
-    if os.environ.get('USE_PROXYFIX', None) == 'true':
-        from werkzeug.contrib.fixers import ProxyFix
     app.wsgi_app = ProxyFix(app.wsgi_app)
     app.run(host='0.0.0.0', port=port_number)


### PR DESCRIPTION
ProxyFix was imported in the global imports, and then conditionally imported
again in the main block.  Moved the conditional import to be a component of the
global import function instead of in the main block, and added comments about
using this as a module and still using the ProxyFix.