### PR TITLE
ProxyFix in __main__ not conditional

### DIFF
--- a/index.py
+++ b/index.py
@@ -124,5 +124,6 @@ if __name__ == "__main__":
         port_number = int(sys.argv[1])
     except:
         port_number = 80
-    app.wsgi_app = ProxyFix(app.wsgi_app)
+    if os.environ.get('USE_PROXYFIX', None) == 'true':
+        app.wsgi_app = ProxyFix(app.wsgi_app)
     app.run(host='0.0.0.0', port=port_number)


### PR DESCRIPTION
Missed that the use of ProxyFix although attempting to be imported
conditionally was not being used conditionally in the main block.  This makes
the call to use ProxyFix conditional as well.