### PR TITLE
GitHub Enterprise Support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,29 @@
 Flask webhook for Github
 ########################
-A very simple github post-receive web hook handler that executes per default a pull uppon receiving. The executed action is configurable per repository.
+A very simple github post-receive web hook handler that executes per default a
+pull uppon receiving. The executed action is configurable per repository.
 
-It will also verify that the POST request originated from github.com and has a valid signature (only when the ``key`` setting is properly configured).
+It will also verify that the POST request originated from github.com or a
+defined GitHub Enterprise server.  Additionally will ensure that it has a valid
+signature (only when the ``key`` setting is properly configured).
 
 Gettings started
 ----------------
 
-Edit ``repos.json`` to configure repositories, each repository must be registered under the form ``GITHUB_USER/REPOSITORY_NAME``.
+Installation Requirements
+=========================
+
+Install dependencies found in ``requirements.txt``.
+
+.. code-block:: console
+
+    pip install -r requirements.txt
+
+Repository Configuration
+========================
+
+Edit ``repos.json`` to configure repositories, each repository must be
+registered under the form ``GITHUB_USER/REPOSITORY_NAME``.
 
 .. code-block:: json
 
@@ -25,18 +41,22 @@ Edit ``repos.json`` to configure repositories, each repository must be registere
 	}
     }
 
-Install dependencies.
+Runtime Configuration
+=====================
 
-.. code-block:: console
+Runtime operation is influenced by a set of environment variables which require
+being set to influence operation.  Only REPOS_JSON_PATH is required to be set,
+as this is required to know how to act on actions from repositories.  The
+remaining variables are optional.  USE_PROXYFIX needs to be set to true if
+being used behind a WSGI proxy, and is not required otherwise.  GHE_ADDRESS
+needs to be set to the IP address of a GitHub Enterprise instance if that is
+the source of webhooks.
 
-    pip install -r requirements.txt
-
-    
 Set environment variable for the ``repos.json`` config.
 
 .. code-block:: console
 
-    export FLASK_GITHUB_WEBHOOK_REPOS_JSON=/path/to/repos.json
+    export REPOS_JSON_PATH=/path/to/repos.json
 
 Start the server.
 
@@ -44,12 +64,20 @@ Start the server.
 
     python index.py 80
 
-Start the server behind a proxy (see: http://flask.pocoo.org/docs/deploying/wsgi-standalone/#proxy-setups)
+Start the server behind a proxy (see:
+http://flask.pocoo.org/docs/deploying/wsgi-standalone/#proxy-setups)
 
 .. code-block:: console
 
     USE_PROXYFIX=true python index.py 8080
 
+Start the server to be used with a GitHub Enterprise instance.
+
+.. code-block:: console
+
+   GHE_ADDRESS=192.0.2.50 python index.py 80
 
 
-Go to your repository's settings on `github.com <http://github.com>`_ and register your public URL under ``Service Hooks -> WebHook URLs``.
+Go to your repository's settings on `github.com <http://github.com>`_ or your
+GitHub Enterprise instance and register your public URL under
+``Service Hooks -> WebHook URLs``.


### PR DESCRIPTION
Add support for GitHub Enterprise

* Capture the request IP before entering the for loop, rename variable from ip
  to request_ip for uniqueness in any future work with IP addresses.

* Look for environment variable GHE_ADDRESS and set it as the hook_blocks list
  if present.

* Fallback to the public API if GHE_ADDRESS is not set.

* Updated documentation to reflect the current environment variables that can be
  used as well as added documentation on using it with a GitHub Enterprise
  instance.