### PR TITLE
Fix loading IP from env

### DIFF
--- a/index.py
+++ b/index.py
@@ -44,7 +44,7 @@ def index():
 
         # If GHE_ADDRESS is specified, use it as the hook_blocks.
         if os.environ.get('GHE_ADDRESS', None):
-            hook_blocks = [os.environ.get('GHE_ADDRESS')]
+            hook_blocks = [unicode(os.environ.get('GHE_ADDRESS'))]
         # Otherwise get the hook address blocks from the API.
         else:
             hook_blocks = requests.get('https://api.github.com/meta').json()[


### PR DESCRIPTION
The ipaddress module requires IP addresses to be passed in as unicode objects, not strings.  Without this, a user attempting to make use of `GHE_ADDRESS` error will receive `ValueError: '127.0.0.1' does not appear to be an IPv4 or IPv6 network`.