### PR TITLE
Filtering for localhost in case ngrok is used

### DIFF
--- a/index.py
+++ b/index.py
@@ -55,7 +55,8 @@ def index():
             if ipaddress.ip_address(request_ip) in ipaddress.ip_network(block):
                 break  # the remote_addr is within the network range of github.
         else:
-            abort(403)
+            if str(request_ip) != '127.0.0.1':                 
+                abort(403)            
 
         if request.headers.get('X-GitHub-Event') == "ping":
             return json.dumps({'msg': 'Hi!'})


### PR DESCRIPTION
If you are proxying through ngrok, the request is from 127.0.0.1 which gets blocked in the IP filtering. This checks for 127.0.0.1 and doesn't return a 403 is the address is a loopback.

Might resolve Issue #18  since I was running into the same thing. 